### PR TITLE
Dependency update (#94)

### DIFF
--- a/.github/workflows/melinda-node-tests.yml
+++ b/.github/workflows/melinda-node-tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 19.x]
+        node-version: [16.x, 18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -97,7 +97,7 @@ jobs:
           username: ${{ secrets.MELINDA_QUAY_IO_USERNAME }}
           password: ${{ secrets.MELINDA_QUAY_IO_PASSWORD }}
       - name: Build and publish image to Quay.io
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-record-import-transformer-helmet",
-	"version": "1.0.1-alpha.2",
+	"version": "1.0.1-alpha.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-record-import-transformer-helmet",
-			"version": "1.0.1-alpha.2",
+			"version": "1.0.1-alpha.3",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "latest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@natlibfi/marc-record-validators-melinda": "^10.9.3",
 				"@natlibfi/melinda-backend-commons": "^2.2.1",
 				"@natlibfi/melinda-commons": "^13.0.5",
-				"@natlibfi/melinda-record-import-commons": "^10.1.6",
+				"@natlibfi/melinda-record-import-commons": "^10.1.7",
 				"amqplib": ">=0.10.3 <1.0.0",
 				"moment": "^2.29.4",
 				"stream-chain": "^2.2.5",
@@ -41,7 +41,7 @@
 				"nyc": "^15.1.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -2255,9 +2255,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-import-commons": {
-			"version": "10.1.6",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-import-commons/-/melinda-record-import-commons-10.1.6.tgz",
-			"integrity": "sha512-PXMAh43YG5Vvy2MajCfxhZ8G3zQyCXr6xSD8azrPBvJQbvZsLgRs7VxHrMwzN5tf0XTOacLQ2dA6znXyKwZsew==",
+			"version": "10.1.7",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-import-commons/-/melinda-record-import-commons-10.1.7.tgz",
+			"integrity": "sha512-qFG0gG8ucEMBpBOV39mZF5gExPvTmSFwnZvruArBm+8ngoKgau7fuRUfjhGj21QxLtWKXry4oX3VKo7jtq/7jA==",
 			"dependencies": {
 				"@natlibfi/melinda-backend-commons": "^2.2.1",
 				"@natlibfi/melinda-commons": "^13.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.1-alpha.3",
 			"license": "AGPL-3.0+",
 			"dependencies": {
-				"@babel/runtime": "latest",
+				"@babel/runtime": "7.22.10",
 				"@natlibfi/marc-record": "^7.2.4",
 				"@natlibfi/marc-record-validate": "^8.0.1",
 				"@natlibfi/marc-record-validators-melinda": "^10.9.3",
@@ -22,13 +22,13 @@
 				"stream-json": "^1.8.0"
 			},
 			"devDependencies": {
-				"@babel/cli": "^7.22.9",
-				"@babel/core": "latest",
-				"@babel/eslint-parser": "latest",
-				"@babel/node": "^7.22.6",
-				"@babel/preset-env": "latest",
+				"@babel/cli": "^7.22.10",
+				"@babel/core": "7.22.10",
+				"@babel/eslint-parser": "7.22.10",
+				"@babel/node": "^7.22.10",
+				"@babel/preset-env": "7.22.10",
 				"@babel/register": "^7.22.5",
-				"@natlibfi/eslint-config-melinda-backend": "^3.0.0",
+				"@natlibfi/eslint-config-melinda-backend": "^3.0.1",
 				"@natlibfi/fixugen": "^2.0.1",
 				"@natlibfi/fixura": "^3.0.1",
 				"babel-plugin-rewire": "^1.2.0",
@@ -79,9 +79,9 @@
 			}
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.22.9.tgz",
-			"integrity": "sha512-nb2O7AThqRo7/E53EGiuAkMaRbb7J5Qp3RvN+dmua1U+kydm0oznkhqbTEG15yk26G/C3yL6OdZjzgl+DMXVVA==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.22.10.tgz",
+			"integrity": "sha512-rM9ZMmaII630zGvtMtQ3P4GyHs28CHLYE9apLG7L8TgaSqcfoIGrlLSLsh4Q8kDTdZQQEXZm1M0nQtOvU/2heg==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.17",
@@ -108,11 +108,12 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-			"integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
+			"integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
 			"dependencies": {
-				"@babel/highlight": "^7.22.5"
+				"@babel/highlight": "^7.22.10",
+				"chalk": "^2.4.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -127,20 +128,20 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
-			"integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
+			"integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.22.5",
-				"@babel/generator": "^7.22.9",
-				"@babel/helper-compilation-targets": "^7.22.9",
+				"@babel/code-frame": "^7.22.10",
+				"@babel/generator": "^7.22.10",
+				"@babel/helper-compilation-targets": "^7.22.10",
 				"@babel/helper-module-transforms": "^7.22.9",
-				"@babel/helpers": "^7.22.6",
-				"@babel/parser": "^7.22.7",
+				"@babel/helpers": "^7.22.10",
+				"@babel/parser": "^7.22.10",
 				"@babel/template": "^7.22.5",
-				"@babel/traverse": "^7.22.8",
-				"@babel/types": "^7.22.5",
+				"@babel/traverse": "^7.22.10",
+				"@babel/types": "^7.22.10",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -156,9 +157,9 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.9.tgz",
-			"integrity": "sha512-xdMkt39/nviO/4vpVdrEYPwXCsYIXSSAr6mC7WQsNIlGnuxKyKE7GZjalcnbSWiC4OXGNNN3UQPeHfjSC6sTDA==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.10.tgz",
+			"integrity": "sha512-0J8DNPRXQRLeR9rPaUMM3fA+RbixjnVLe/MRMYCkp3hzgsSuxCHQ8NN8xQG1wIHKJ4a1DTROTvFJdW+B5/eOsg==",
 			"dev": true,
 			"dependencies": {
 				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -169,16 +170,16 @@
 				"node": "^10.13.0 || ^12.13.0 || >=14.0.0"
 			},
 			"peerDependencies": {
-				"@babel/core": ">=7.11.0",
+				"@babel/core": "^7.11.0",
 				"eslint": "^7.5.0 || ^8.0.0"
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.9.tgz",
-			"integrity": "sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
+			"integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
 			"dependencies": {
-				"@babel/types": "^7.22.5",
+				"@babel/types": "^7.22.10",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -212,9 +213,9 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.9.tgz",
-			"integrity": "sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
+			"integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
 			"dependencies": {
 				"@babel/compat-data": "^7.22.9",
 				"@babel/helper-validator-option": "^7.22.5",
@@ -224,9 +225,6 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
@@ -485,25 +483,25 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.6.tgz",
-			"integrity": "sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.10.tgz",
+			"integrity": "sha512-a41J4NW8HyZa1I1vAndrraTlPZ/eZoga2ZgS7fEr0tZJGVU4xqdE80CEm0CcNjha5EZ8fTBYLKHF0kqDUuAwQw==",
 			"dependencies": {
 				"@babel/template": "^7.22.5",
-				"@babel/traverse": "^7.22.6",
-				"@babel/types": "^7.22.5"
+				"@babel/traverse": "^7.22.10",
+				"@babel/types": "^7.22.10"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-			"integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
+			"integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.22.5",
-				"chalk": "^2.0.0",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			},
 			"engines": {
@@ -511,16 +509,16 @@
 			}
 		},
 		"node_modules/@babel/node": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/node/-/node-7.22.6.tgz",
-			"integrity": "sha512-Lt6v+RUQOTsEOXLv+KfjogLFkFfsLPPSoXZqmbngfVatkWjQPnFGHO0xjFRcN6XEvm3vsnZn+AWQiRpgZFsdIA==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/node/-/node-7.22.10.tgz",
+			"integrity": "sha512-FpSgdjIPabpEetDxtKYAcXCs0qRh12S2D40rhpRoo0w5h7/7Tu2ZroaX99cbKFNDODiSs484sZ1q0kutJbZ2iQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/register": "^7.22.5",
 				"commander": "^4.0.1",
 				"core-js": "^3.30.2",
 				"node-environment-flags": "^1.0.5",
-				"regenerator-runtime": "^0.13.11",
+				"regenerator-runtime": "^0.14.0",
 				"v8flags": "^3.1.1"
 			},
 			"bin": {
@@ -534,9 +532,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.22.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-			"integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.10.tgz",
+			"integrity": "sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -583,22 +581,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.18.6.tgz",
-			"integrity": "sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.18.6"
-			},
-			"engines": {
-				"node": ">=4"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
@@ -855,14 +837,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.22.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.7.tgz",
-			"integrity": "sha512-7HmE7pk/Fmke45TODvxvkxRMV9RazV+ZZzhOL9AG8G29TLrr3jkjwF7uJfxZ30EoXpO+LJkq4oA8NjO2DTnEDg==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.10.tgz",
+			"integrity": "sha512-eueE8lvKVzq5wIObKK/7dvoeKJ+xc6TvRn6aysIjS6pSCeLy7S/eVi7pEQknZqyqvzaNKdDtem8nUNTBgDVR2g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.5",
 				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-remap-async-to-generator": "^7.22.5",
+				"@babel/helper-remap-async-to-generator": "^7.22.9",
 				"@babel/plugin-syntax-async-generators": "^7.8.4"
 			},
 			"engines": {
@@ -905,9 +887,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.22.5.tgz",
-			"integrity": "sha512-EcACl1i5fSQ6bt+YGuU/XGCeZKStLmyVGytWkpyhCLeQVA0eu6Wtiw92V+I1T/hnezUv7j74dA/Ro69gWcU+hg==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.22.10.tgz",
+			"integrity": "sha512-1+kVpGAOOI1Albt6Vse7c8pHzcZQdQKW+wJH+g8mCaszOdDVwRXa/slHPqIw+oJAJANTKDMuM2cBdV0Dg618Vg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -992,9 +974,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.22.5.tgz",
-			"integrity": "sha512-GfqcFuGW8vnEqTUBM7UtPd5A4q797LTvvwKxXTgRsFjoqaJiEg9deBG6kWeQYkVEL569NpnmpC0Pkr/8BLKGnQ==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.22.10.tgz",
+			"integrity": "sha512-dPJrL0VOyxqLM9sritNbMSGx/teueHF/htMKrPT7DNxccXxRDPYqlgPFFdr8u+F+qUZOkZoXue/6rL5O5GduEw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1361,9 +1343,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-chaining": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.6.tgz",
-			"integrity": "sha512-Vd5HiWml0mDVtcLHIoEU5sw6HOUW/Zk0acLs/SAeuLzkGNOPc9DB4nkUajemhCmTIz3eiaKREZn2hQQqF79YTg==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.10.tgz",
+			"integrity": "sha512-MMkQqZAZ+MGj+jGTG3OTuhKeBpNcO+0oCEbrGNEaOmiEn+1MzRyQlYsruGiU8RTK3zV6XwrVJTmwiDOyYK6J9g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
@@ -1442,13 +1424,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.22.5.tgz",
-			"integrity": "sha512-rR7KePOE7gfEtNTh9Qw+iO3Q/e4DEsoQ+hdvM6QUDH7JRJ5qxq5AA52ZzBWbI5i9lfNuvySgOGP8ZN7LAmaiPw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.22.10.tgz",
+			"integrity": "sha512-F28b1mDt8KcT5bUyJc/U9nwzw6cV+UmTeRlXYIl2TNqMMJif0Jeey9/RQ3C4NOd2zp0/TRsDns9ttj2L523rsw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5",
-				"regenerator-transform": "^0.15.1"
+				"regenerator-transform": "^0.15.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1549,9 +1531,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-escapes": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.22.5.tgz",
-			"integrity": "sha512-biEmVg1IYB/raUO5wT1tgfacCef15Fbzhkx493D3urBI++6hpJ+RFG4SrWMn0NEZLfvilqKf3QDrRVZHo08FYg==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.22.10.tgz",
+			"integrity": "sha512-lRfaRKGZCBqDlRU3UIFovdp9c9mEvlylmpod0/OatICsSfuQ9YFthRo1tpTkGsklEefZdqlEFdY4A2dwTb6ohg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.22.5"
@@ -1612,13 +1594,13 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.22.9",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.9.tgz",
-			"integrity": "sha512-wNi5H/Emkhll/bqPjsjQorSykrlfY5OWakd6AulLvMEytpKasMVUpVy8RL4qBIBs5Ac6/5i0/Rv0b/Fg6Eag/g==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.10.tgz",
+			"integrity": "sha512-riHpLb1drNkpLlocmSyEg4oYJIQFeXAK/d7rI6mbD0XsvoTOOweXDmQPG/ErxsEhWk3rl3Q/3F6RFQlVFS8m0A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.22.9",
-				"@babel/helper-compilation-targets": "^7.22.9",
+				"@babel/helper-compilation-targets": "^7.22.10",
 				"@babel/helper-plugin-utils": "^7.22.5",
 				"@babel/helper-validator-option": "^7.22.5",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.22.5",
@@ -1643,15 +1625,15 @@
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.22.5",
-				"@babel/plugin-transform-async-generator-functions": "^7.22.7",
+				"@babel/plugin-transform-async-generator-functions": "^7.22.10",
 				"@babel/plugin-transform-async-to-generator": "^7.22.5",
 				"@babel/plugin-transform-block-scoped-functions": "^7.22.5",
-				"@babel/plugin-transform-block-scoping": "^7.22.5",
+				"@babel/plugin-transform-block-scoping": "^7.22.10",
 				"@babel/plugin-transform-class-properties": "^7.22.5",
 				"@babel/plugin-transform-class-static-block": "^7.22.5",
 				"@babel/plugin-transform-classes": "^7.22.6",
 				"@babel/plugin-transform-computed-properties": "^7.22.5",
-				"@babel/plugin-transform-destructuring": "^7.22.5",
+				"@babel/plugin-transform-destructuring": "^7.22.10",
 				"@babel/plugin-transform-dotall-regex": "^7.22.5",
 				"@babel/plugin-transform-duplicate-keys": "^7.22.5",
 				"@babel/plugin-transform-dynamic-import": "^7.22.5",
@@ -1674,27 +1656,27 @@
 				"@babel/plugin-transform-object-rest-spread": "^7.22.5",
 				"@babel/plugin-transform-object-super": "^7.22.5",
 				"@babel/plugin-transform-optional-catch-binding": "^7.22.5",
-				"@babel/plugin-transform-optional-chaining": "^7.22.6",
+				"@babel/plugin-transform-optional-chaining": "^7.22.10",
 				"@babel/plugin-transform-parameters": "^7.22.5",
 				"@babel/plugin-transform-private-methods": "^7.22.5",
 				"@babel/plugin-transform-private-property-in-object": "^7.22.5",
 				"@babel/plugin-transform-property-literals": "^7.22.5",
-				"@babel/plugin-transform-regenerator": "^7.22.5",
+				"@babel/plugin-transform-regenerator": "^7.22.10",
 				"@babel/plugin-transform-reserved-words": "^7.22.5",
 				"@babel/plugin-transform-shorthand-properties": "^7.22.5",
 				"@babel/plugin-transform-spread": "^7.22.5",
 				"@babel/plugin-transform-sticky-regex": "^7.22.5",
 				"@babel/plugin-transform-template-literals": "^7.22.5",
 				"@babel/plugin-transform-typeof-symbol": "^7.22.5",
-				"@babel/plugin-transform-unicode-escapes": "^7.22.5",
+				"@babel/plugin-transform-unicode-escapes": "^7.22.10",
 				"@babel/plugin-transform-unicode-property-regex": "^7.22.5",
 				"@babel/plugin-transform-unicode-regex": "^7.22.5",
 				"@babel/plugin-transform-unicode-sets-regex": "^7.22.5",
-				"@babel/preset-modules": "^0.1.5",
-				"@babel/types": "^7.22.5",
-				"babel-plugin-polyfill-corejs2": "^0.4.4",
-				"babel-plugin-polyfill-corejs3": "^0.8.2",
-				"babel-plugin-polyfill-regenerator": "^0.5.1",
+				"@babel/preset-modules": "0.1.6-no-external-plugins",
+				"@babel/types": "^7.22.10",
+				"babel-plugin-polyfill-corejs2": "^0.4.5",
+				"babel-plugin-polyfill-corejs3": "^0.8.3",
+				"babel-plugin-polyfill-regenerator": "^0.5.2",
 				"core-js-compat": "^3.31.0",
 				"semver": "^6.3.1"
 			},
@@ -1706,14 +1688,12 @@
 			}
 		},
 		"node_modules/@babel/preset-modules": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6.tgz",
-			"integrity": "sha512-ID2yj6K/4lKfhuU3+EX4UvNbIt7eACFbHmNUjzA+ep+B5971CknnA/9DEWKbRokfbbtblxxxXFJJrH47UEAMVg==",
+			"version": "0.1.6-no-external-plugins",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+			"integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
-				"@babel/plugin-transform-dotall-regex": "^7.4.4",
 				"@babel/types": "^7.4.4",
 				"esutils": "^2.0.2"
 			},
@@ -1746,11 +1726,11 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-			"integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+			"integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
 			"dependencies": {
-				"regenerator-runtime": "^0.13.11"
+				"regenerator-runtime": "^0.14.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1770,18 +1750,18 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.22.8",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
-			"integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
+			"integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
 			"dependencies": {
-				"@babel/code-frame": "^7.22.5",
-				"@babel/generator": "^7.22.7",
+				"@babel/code-frame": "^7.22.10",
+				"@babel/generator": "^7.22.10",
 				"@babel/helper-environment-visitor": "^7.22.5",
 				"@babel/helper-function-name": "^7.22.5",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.22.7",
-				"@babel/types": "^7.22.5",
+				"@babel/parser": "^7.22.10",
+				"@babel/types": "^7.22.10",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -1790,9 +1770,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
-			"integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+			"version": "7.22.10",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.10.tgz",
+			"integrity": "sha512-obaoigiLrlDZ7TUQln/8m4mSqIW2QFeOrCQc9r+xsaHGNoplVNYlRVpsfE8Vj35GEm2ZH4ZhrNYogs/3fj85kg==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.22.5",
 				"@babel/helper-validator-identifier": "^7.22.5",
@@ -2105,9 +2085,9 @@
 			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
 		},
 		"node_modules/@natlibfi/eslint-config-melinda-backend": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-3.0.0.tgz",
-			"integrity": "sha512-Nn/jPwvwSY44xczjDiU0eR4t3Awbfc/nYrromiSn6Atx7h6V87rcXrAr1E1QtXKDWg/+7b36zNdBxO5mkaBliA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-3.0.1.tgz",
+			"integrity": "sha512-9DLr4o0hoSR7YToevR9IIES5btPr83ZvYqbzI6vMRkrcQKjQLCVBTGKKBQA4z7e2ZhI45grbN61tj7m4sNV3+Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/eslint-parser": "^7.21.3",
@@ -6464,14 +6444,14 @@
 			}
 		},
 		"node_modules/regenerator-runtime": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+			"integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
 		},
 		"node_modules/regenerator-transform": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.1.tgz",
-			"integrity": "sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==",
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
+			"integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.8.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-record-import-transformer-helmet",
-	"version": "1.0.1-alpha.3",
+	"version": "1.0.1-alpha.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-record-import-transformer-helmet",
-			"version": "1.0.1-alpha.3",
+			"version": "1.0.1-alpha.4",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "7.22.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,41 +1,41 @@
 {
 	"name": "@natlibfi/melinda-record-import-transformer-helmet",
-	"version": "1.0.0",
+	"version": "1.0.1-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-record-import-transformer-helmet",
-			"version": "1.0.0",
+			"version": "1.0.1-alpha.2",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "latest",
-				"@natlibfi/marc-record": "^7.2.2",
-				"@natlibfi/marc-record-validate": "^8.0.0",
-				"@natlibfi/marc-record-validators-melinda": "^10.9.2",
-				"@natlibfi/melinda-backend-commons": "^2.2.0",
-				"@natlibfi/melinda-commons": "^13.0.4",
-				"@natlibfi/melinda-record-import-commons": "^10.1.6-alpha.4",
+				"@natlibfi/marc-record": "^7.2.4",
+				"@natlibfi/marc-record-validate": "^8.0.1",
+				"@natlibfi/marc-record-validators-melinda": "^10.9.3",
+				"@natlibfi/melinda-backend-commons": "^2.2.1",
+				"@natlibfi/melinda-commons": "^13.0.5",
+				"@natlibfi/melinda-record-import-commons": "^10.1.6",
 				"amqplib": ">=0.10.3 <1.0.0",
 				"moment": "^2.29.4",
 				"stream-chain": "^2.2.5",
-				"stream-json": "^1.7.5"
+				"stream-json": "^1.8.0"
 			},
 			"devDependencies": {
-				"@babel/cli": "^7.22.6",
+				"@babel/cli": "^7.22.9",
 				"@babel/core": "latest",
 				"@babel/eslint-parser": "latest",
 				"@babel/node": "^7.22.6",
 				"@babel/preset-env": "latest",
 				"@babel/register": "^7.22.5",
 				"@natlibfi/eslint-config-melinda-backend": "^3.0.0",
-				"@natlibfi/fixugen": "^2.0.0",
-				"@natlibfi/fixura": "^3.0.0",
+				"@natlibfi/fixugen": "^2.0.1",
+				"@natlibfi/fixura": "^3.0.1",
 				"babel-plugin-rewire": "^1.2.0",
-				"chai": "^4.3.6",
+				"chai": "^4.3.7",
 				"chai-as-promised": "^7.1.1",
 				"cross-env": "^7.0.3",
-				"eslint": "^8.44.0",
+				"eslint": "^8.46.0",
 				"mocha": "^10.2.0",
 				"nodemon": "^3.0.1",
 				"nyc": "^15.1.0"
@@ -79,9 +79,9 @@
 			}
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.22.6.tgz",
-			"integrity": "sha512-Be3/RfEDmkMRGT1+ru5nTkfcvWz5jDOYg1V9rXqTz2u9Qt96O1ryboGvxVBp7wOnYWDB8DNHIWb6DThrpudfOw==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.22.9.tgz",
+			"integrity": "sha512-nb2O7AThqRo7/E53EGiuAkMaRbb7J5Qp3RvN+dmua1U+kydm0oznkhqbTEG15yk26G/C3yL6OdZjzgl+DMXVVA==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.17",
@@ -119,33 +119,33 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.6.tgz",
-			"integrity": "sha512-29tfsWTq2Ftu7MXmimyC0C5FDZv5DYxOZkh3XD3+QW4V/BYuv/LyEsjj3c0hqedEaDt6DBfDvexMKU8YevdqFg==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
+			"integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.22.8",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.8.tgz",
-			"integrity": "sha512-75+KxFB4CZqYRXjx4NlR4J7yGvKumBuZTmV4NV6v09dVXXkuYVYLT68N6HCzLvfJ+fWCxQsntNzKwwIXL4bHnw==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
+			"integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.22.5",
-				"@babel/generator": "^7.22.7",
-				"@babel/helper-compilation-targets": "^7.22.6",
-				"@babel/helper-module-transforms": "^7.22.5",
+				"@babel/generator": "^7.22.9",
+				"@babel/helper-compilation-targets": "^7.22.9",
+				"@babel/helper-module-transforms": "^7.22.9",
 				"@babel/helpers": "^7.22.6",
 				"@babel/parser": "^7.22.7",
 				"@babel/template": "^7.22.5",
 				"@babel/traverse": "^7.22.8",
 				"@babel/types": "^7.22.5",
-				"@nicolo-ribaudo/semver-v6": "^6.3.3",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.2"
+				"json5": "^2.2.2",
+				"semver": "^6.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -156,14 +156,14 @@
 			}
 		},
 		"node_modules/@babel/eslint-parser": {
-			"version": "7.22.7",
-			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.7.tgz",
-			"integrity": "sha512-LH6HJqjOyu/Qtp7LuSycZXK/CYXQ4ohdkliEaL1QTdtOXVdOVpTBKVxAo/+eeyt+x/2SRzB+zUPduVl+xiEvdg==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.9.tgz",
+			"integrity": "sha512-xdMkt39/nviO/4vpVdrEYPwXCsYIXSSAr6mC7WQsNIlGnuxKyKE7GZjalcnbSWiC4OXGNNN3UQPeHfjSC6sTDA==",
 			"dev": true,
 			"dependencies": {
 				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-				"@nicolo-ribaudo/semver-v6": "^6.3.3",
-				"eslint-visitor-keys": "^2.1.0"
+				"eslint-visitor-keys": "^2.1.0",
+				"semver": "^6.3.1"
 			},
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || >=14.0.0"
@@ -174,9 +174,9 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.22.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.7.tgz",
-			"integrity": "sha512-p+jPjMG+SI8yvIaxGgeW24u7q9+5+TGpZh8/CuB7RhBKd7RCy8FayNEFNNKrNK/eUcY/4ExQqLmyrvBXKsIcwQ==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.9.tgz",
+			"integrity": "sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==",
 			"dependencies": {
 				"@babel/types": "^7.22.5",
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -212,15 +212,15 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.6.tgz",
-			"integrity": "sha512-534sYEqWD9VfUm3IPn2SLcH4Q3P86XL+QvqdC7ZsFrzyyPF3T4XGiVghF6PTYNdWg6pXuoqXxNQAhbYeEInTzA==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.9.tgz",
+			"integrity": "sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==",
 			"dependencies": {
-				"@babel/compat-data": "^7.22.6",
+				"@babel/compat-data": "^7.22.9",
 				"@babel/helper-validator-option": "^7.22.5",
-				"@nicolo-ribaudo/semver-v6": "^6.3.3",
 				"browserslist": "^4.21.9",
-				"lru-cache": "^5.1.1"
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -230,9 +230,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.6.tgz",
-			"integrity": "sha512-iwdzgtSiBxF6ni6mzVnZCF3xt5qE6cEA0J7nFt8QOAWZ0zjCFceEgpn3vtb2V7WFR6QzP2jmIFOHMTRo7eNJjQ==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.9.tgz",
+			"integrity": "sha512-Pwyi89uO4YrGKxL/eNJ8lfEH55DnRloGPOseaA8NFNL6jAUnn+KccaISiFazCj5IolPPDjGSdzQzXVzODVRqUQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
@@ -240,10 +240,10 @@
 				"@babel/helper-function-name": "^7.22.5",
 				"@babel/helper-member-expression-to-functions": "^7.22.5",
 				"@babel/helper-optimise-call-expression": "^7.22.5",
-				"@babel/helper-replace-supers": "^7.22.5",
+				"@babel/helper-replace-supers": "^7.22.9",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@nicolo-ribaudo/semver-v6": "^6.3.3"
+				"semver": "^6.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -253,14 +253,14 @@
 			}
 		},
 		"node_modules/@babel/helper-create-regexp-features-plugin": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.6.tgz",
-			"integrity": "sha512-nBookhLKxAWo/TUCmhnaEJyLz2dekjQvv5SRpE9epWQBcpedWLKt8aZdsuT9XV5ovzR3fENLjRXVT0GsSlGGhA==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.9.tgz",
+			"integrity": "sha512-+svjVa/tFwsNSG4NEy1h85+HQ5imbT92Q5/bgtS7P0GTQlP8WuFdqsiABmQouhiFGyV66oGxZFpeYHza1rNsKw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@nicolo-ribaudo/semver-v6": "^6.3.3",
-				"regexpu-core": "^5.3.1"
+				"regexpu-core": "^5.3.1",
+				"semver": "^6.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -270,9 +270,9 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.1.tgz",
-			"integrity": "sha512-kX4oXixDxG197yhX+J3Wp+NpL2wuCFjWQAr6yX2jtCnflK9ulMI51ULFGIrWiX1jGfvAxdHp+XQCcP2bZGPs9A==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.2.tgz",
+			"integrity": "sha512-k0qnnOqHn5dK9pZpfD5XXZ9SojAITdCKRn2Lp6rnDGzIbaP0rHyMPk/4wsSxVBVz4RfN0q6VpXWP2pDGIoQ7hw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-compilation-targets": "^7.22.6",
@@ -282,7 +282,7 @@
 				"resolve": "^1.14.2"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.4.0-0"
+				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/@babel/helper-environment-visitor": {
@@ -340,21 +340,21 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.5.tgz",
-			"integrity": "sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.9.tgz",
+			"integrity": "sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==",
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.5",
 				"@babel/helper-module-imports": "^7.22.5",
 				"@babel/helper-simple-access": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.22.5",
-				"@babel/helper-validator-identifier": "^7.22.5",
-				"@babel/template": "^7.22.5",
-				"@babel/traverse": "^7.22.5",
-				"@babel/types": "^7.22.5"
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-validator-identifier": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/@babel/helper-optimise-call-expression": {
@@ -379,15 +379,14 @@
 			}
 		},
 		"node_modules/@babel/helper-remap-async-to-generator": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.5.tgz",
-			"integrity": "sha512-cU0Sq1Rf4Z55fgz7haOakIyM7+x/uCFwXpLPaeRzfoUtAEAuUZjZvFPjL/rk5rW693dIgn2hng1W7xbT7lWT4g==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.9.tgz",
+			"integrity": "sha512-8WWC4oR4Px+tr+Fp0X3RHDVfINGpF3ad1HIbrc8A77epiR6eMMc6jsgozkzT2uDiOOdoS9cLIQ+XD2XvI2WSmQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
 				"@babel/helper-environment-visitor": "^7.22.5",
-				"@babel/helper-wrap-function": "^7.22.5",
-				"@babel/types": "^7.22.5"
+				"@babel/helper-wrap-function": "^7.22.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -397,20 +396,20 @@
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.5.tgz",
-			"integrity": "sha512-aLdNM5I3kdI/V9xGNyKSF3X/gTyMUBohTZ+/3QdQKAA9vxIiy12E+8E2HoOP1/DjeqU+g6as35QHJNMDDYpuCg==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.9.tgz",
+			"integrity": "sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.5",
 				"@babel/helper-member-expression-to-functions": "^7.22.5",
-				"@babel/helper-optimise-call-expression": "^7.22.5",
-				"@babel/template": "^7.22.5",
-				"@babel/traverse": "^7.22.5",
-				"@babel/types": "^7.22.5"
+				"@babel/helper-optimise-call-expression": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/@babel/helper-simple-access": {
@@ -472,14 +471,13 @@
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.5.tgz",
-			"integrity": "sha512-bYqLIBSEshYcYQyfks8ewYA8S30yaGSeRslcvKMvoUk6HHPySbxHq9YRi6ghhzEU+yhQv9bP/jXnygkStOcqZw==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.9.tgz",
+			"integrity": "sha512-sZ+QzfauuUEfxSEjKFmi3qDSHgLsTPK/pEpoD/qonZKOtTPTLbf59oabPQ4rKekt9lFcj/hTZaOhWwFYrgjk+Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-function-name": "^7.22.5",
 				"@babel/template": "^7.22.5",
-				"@babel/traverse": "^7.22.5",
 				"@babel/types": "^7.22.5"
 			},
 			"engines": {
@@ -1614,13 +1612,13 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.22.7",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.7.tgz",
-			"integrity": "sha512-1whfDtW+CzhETuzYXfcgZAh8/GFMeEbz0V5dVgya8YeJyCU6Y/P2Gnx4Qb3MylK68Zu9UiwUvbPMPTpFAOJ+sQ==",
+			"version": "7.22.9",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.9.tgz",
+			"integrity": "sha512-wNi5H/Emkhll/bqPjsjQorSykrlfY5OWakd6AulLvMEytpKasMVUpVy8RL4qBIBs5Ac6/5i0/Rv0b/Fg6Eag/g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.22.6",
-				"@babel/helper-compilation-targets": "^7.22.6",
+				"@babel/compat-data": "^7.22.9",
+				"@babel/helper-compilation-targets": "^7.22.9",
 				"@babel/helper-plugin-utils": "^7.22.5",
 				"@babel/helper-validator-option": "^7.22.5",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.22.5",
@@ -1694,11 +1692,11 @@
 				"@babel/plugin-transform-unicode-sets-regex": "^7.22.5",
 				"@babel/preset-modules": "^0.1.5",
 				"@babel/types": "^7.22.5",
-				"@nicolo-ribaudo/semver-v6": "^6.3.3",
 				"babel-plugin-polyfill-corejs2": "^0.4.4",
 				"babel-plugin-polyfill-corejs3": "^0.8.2",
 				"babel-plugin-polyfill-regenerator": "^0.5.1",
-				"core-js-compat": "^3.31.0"
+				"core-js-compat": "^3.31.0",
+				"semver": "^6.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1708,9 +1706,9 @@
 			}
 		},
 		"node_modules/@babel/preset-modules": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.5.tgz",
-			"integrity": "sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6.tgz",
+			"integrity": "sha512-ID2yj6K/4lKfhuU3+EX4UvNbIt7eACFbHmNUjzA+ep+B5971CknnA/9DEWKbRokfbbtblxxxXFJJrH47UEAMVg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -1720,7 +1718,7 @@
 				"esutils": "^2.0.2"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
+				"@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/@babel/register": {
@@ -1850,18 +1848,18 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-			"integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+			"integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
 			"dev": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-			"integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
+			"integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
@@ -1909,9 +1907,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.44.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-			"integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+			"version": "8.46.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
+			"integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2125,21 +2123,21 @@
 			}
 		},
 		"node_modules/@natlibfi/fixugen": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen/-/fixugen-2.0.0.tgz",
-			"integrity": "sha512-iKVck8EI8Oo4R46X0hGR07+cfOvlUkCnTHnKmz05PlsLkzZccNcD6RtoyFYzZxWqv848l5G1bUQD68Qjnh27gA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen/-/fixugen-2.0.1.tgz",
+			"integrity": "sha512-FU0+VsnPBwaTDh8zXvyaCgr2U9/zqZ252ZldCB26kZIpNsWIgzZBYNJd3VPfH/GRQPAjLjmfi4m8VVTmnwW4TQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@natlibfi/fixura": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixura/-/fixura-3.0.0.tgz",
-			"integrity": "sha512-DyIxsXZ7KkLHnqCqt70+XjzQnwjOTr9Jb/NKlSFgOTpMeMS4hFTg0ExpausfMbnkp6U77i8C+i+kBojpbCvP/A==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/fixura/-/fixura-3.0.1.tgz",
+			"integrity": "sha512-hLzWz3UMTzOfa4NxEMaWnp39I7SNKu/fYyJJJHhHVwWWjnw4PKuZATJSstGo9u3j2VBYg7Izp+3Bg14EdLCAtA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/register": "^7.21.0"
+				"@babel/register": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2151,9 +2149,9 @@
 			"integrity": "sha512-3SowmWr87fGUINSwlN6pK73u8UlifC4AlfpVt4wYGGt7jfaYF31g4fkFiZ2wuKEgna7MxkFs/DkX3f5U1VeCjQ=="
 		},
 		"node_modules/@natlibfi/marc-record": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-7.2.2.tgz",
-			"integrity": "sha512-yIlLMkopODmFO1a7nPlWmjGzhUEJSOScQ0C7DNcYpz3mBLB79Gs6WfZyjycABFkhquZ/MaiY3DO2E4WKVpMF9Q==",
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-7.2.4.tgz",
+			"integrity": "sha512-dB/MEp+oiDgQ800pUucO6NcT0WFMrtG3uwO4Cgge3giQpTM0IJ4Ca6NWDvRKfYMqEiU6pBA1nDh91kFczA8KLA==",
 			"dependencies": {
 				"debug": "^4.3.4",
 				"jsonschema": "^1.4.1"
@@ -2163,15 +2161,15 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-serializers": {
-			"version": "10.0.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-10.0.5.tgz",
-			"integrity": "sha512-Pk1broKgFvigszRlutnBuOoLK8w4Whdpz3io06W9klZcHuIj5afuwSyyxdiKhW7sIaWfbKNmRAcJP4dqeSxBvw==",
+			"version": "10.0.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-10.0.6.tgz",
+			"integrity": "sha512-EXiJatZ7JFC9pk0e5eCh3CFvi54ONS+qQEqI1lQ5FpSSxLTWp18amlh9sZt7vDpJGuWzHpiGFWElo6qE2lIHpg==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^7.2.2",
-				"@xmldom/xmldom": "^0.8.7",
-				"stream-json": "^1.7.5",
-				"xml2js": ">=0.5.0 <1.0.0",
-				"yargs": "^17.7.1"
+				"@xmldom/xmldom": "^0.8.10",
+				"stream-json": "^1.8.0",
+				"xml2js": ">=0.6.2 <1.0.0",
+				"yargs": "^17.7.2"
 			},
 			"bin": {
 				"marc-record-serializers": "dist/cli.js"
@@ -2181,11 +2179,11 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validate": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validate/-/marc-record-validate-8.0.0.tgz",
-			"integrity": "sha512-jhj3Vll+5wHdl8DVINgRcjZSGc2N9ZM7tOGq9opfWYerARasciA1Ds/Qe45/NP3KJflN16bwk3o7oJ4FTTnYdg==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validate/-/marc-record-validate-8.0.1.tgz",
+			"integrity": "sha512-x5lddBxESrmmHEF24uXeYze446r44SwB8e4naKe+qvn1Bds3B7hSqFFq2oNnZ9Ll/p5OeFVUPDyHJIxKyv7ERA==",
 			"dependencies": {
-				"@babel/runtime": "^7.20.13",
+				"@babel/runtime": "^7.22.6",
 				"@natlibfi/marc-record": "^7.2.2"
 			},
 			"engines": {
@@ -2193,21 +2191,21 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "10.9.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-10.9.2.tgz",
-			"integrity": "sha512-he+frOL5AIAtoe7dY8s3Tbm7H7Q+Pk82GWJ/Xjk626i3FxSHjQQg8MSpEibeco+qHVeCq0tFHa1SMZdk0bG5vw==",
+			"version": "10.9.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-10.9.3.tgz",
+			"integrity": "sha512-XiyNzszzVuwxW+RdKw5VAaMle1CFhB+MlqxiC0tHCXrgmIjYhCKRHSTCW4QUQFKDs8SqX6YRiucUgoUV/7ihzA==",
 			"dependencies": {
-				"@babel/register": "^7.21.0",
+				"@babel/register": "^7.22.5",
 				"@natlibfi/issn-verify": "^1.0.0",
 				"@natlibfi/marc-record": "^7.2.2",
-				"@natlibfi/marc-record-validate": "^8.0.0",
+				"@natlibfi/marc-record-validate": "^8.0.1",
 				"cld3-asm": "^3.1.1",
 				"clone": "^2.1.2",
 				"debug": "^4.3.4",
 				"isbn3": "^1.1.39",
 				"langs": "^2.0.0",
-				"node-fetch": "^2.6.9",
-				"xml2js": ">=0.6.0 <1.0.0"
+				"node-fetch": "^2.6.12",
+				"xml2js": ">=0.6.2 <1.0.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2217,9 +2215,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.2.0.tgz",
-			"integrity": "sha512-5qwVKosaeKRuOwmsY12P8pZD6ZOj6LwyGX0HKrHqE7I/D963WFXz6j7TzumoHF+XuPs3nnevtrlEZmlSuCBphA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.2.1.tgz",
+			"integrity": "sha512-Qofe5QQ/JuW9LJEBF41ZBrM5B3/mARoO0i7PsIad5K7S9LQaxl4vHxnNzQOgBQSUcecYagu0cWRxBzL6sjm0nQ==",
 			"dependencies": {
 				"base64-url": "^2.3.3",
 				"debug": "^4.3.4",
@@ -2227,7 +2225,7 @@
 				"moment": "^2.29.4",
 				"pretty-print-ms": "^1.0.5",
 				"uuid": "^9.0.0",
-				"winston": "^3.8.2"
+				"winston": "^3.10.0"
 			},
 			"bin": {
 				"gen-encryption-key": "dist/gen-encryption-key.js",
@@ -2238,112 +2236,53 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.4.tgz",
-			"integrity": "sha512-xcNHbNFbG4fPFRQroQmXyhoHMGD2Ath/CslePzDGLpYDTxHS/vPcPIXfSNFQQXfhcBOBDKF1Z4OKuJMRaNhg2w==",
+			"version": "13.0.5",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.5.tgz",
+			"integrity": "sha512-GLd53pe3zKoVCjIod3Dain5/QiubjslmAnTEi2PBKLk+bBYyL14MeAcsD21mUp23VM8QjwkMHT94ApGphVJQdA==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^7.2.2",
-				"@natlibfi/marc-record-serializers": "^10.0.4",
-				"@natlibfi/sru-client": "^6.0.2",
+				"@natlibfi/marc-record-serializers": "^10.0.6",
+				"@natlibfi/sru-client": "^6.0.4",
 				"debug": "^4.3.4",
 				"deep-eql": "^4.1.3",
 				"http-status": "^1.6.2",
 				"moment": "^2.29.4",
-				"nock": "^13.3.0",
-				"node-fetch": "^2.6.8"
+				"nock": "^13.3.2",
+				"node-fetch": "^2.6.12"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-import-commons": {
-			"version": "10.1.6-alpha.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-import-commons/-/melinda-record-import-commons-10.1.6-alpha.5.tgz",
-			"integrity": "sha512-exFp/PHb6yM9zQDHZefpulUQvg0NqsTDCQRolNLJrASYN5xui7ssZCLaNCdTRzqfg5UpCPMQGqrc7pqkHLbmfw==",
+			"version": "10.1.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-import-commons/-/melinda-record-import-commons-10.1.6.tgz",
+			"integrity": "sha512-PXMAh43YG5Vvy2MajCfxhZ8G3zQyCXr6xSD8azrPBvJQbvZsLgRs7VxHrMwzN5tf0XTOacLQ2dA6znXyKwZsew==",
 			"dependencies": {
-				"@natlibfi/melinda-backend-commons": "^2.0.5",
-				"@natlibfi/melinda-commons": "^12.0.3",
-				"amqplib": ">=0.8.0 <1.0.0",
-				"debug": "^4.3.3",
-				"http-status": "^1.6.1",
-				"moment": "^2.29.1",
-				"node-fetch": "^2.6.7",
-				"rimraf": "^3.0.2",
-				"uuid": "^8.3.2",
-				"yargs": "^17.3.1"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@natlibfi/melinda-record-import-commons/node_modules/@natlibfi/marc-record-serializers": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-9.0.4.tgz",
-			"integrity": "sha512-17w/VL5rZ9NOZiggrlLaYhg8WcuFYuqZU9i0lWqRp9Ed9n8vQ/ihoHJoQeAq03g+1F6yylQp5wXNZ/49RLVwtQ==",
-			"dependencies": {
-				"@natlibfi/marc-record": "^7.2.2",
-				"@xmldom/xmldom": "^0.8.6",
-				"stream-json": "^1.7.5",
-				"xml2js": ">=0.4.23 <1.0.0",
-				"yargs": "^17.6.2"
-			},
-			"bin": {
-				"marc-record-serializers": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/@natlibfi/melinda-record-import-commons/node_modules/@natlibfi/melinda-commons": {
-			"version": "12.0.9",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-12.0.9.tgz",
-			"integrity": "sha512-PHrYz7bOIuzUBwjmgoYkqLK3+nPMaO4TLT8+rTlBKs1P29Uv/k4EWOkOZKTrlYS2xXbGoofbsspWq3+zepjxqg==",
-			"dependencies": {
-				"@natlibfi/marc-record": "^7.2.2",
-				"@natlibfi/marc-record-serializers": "^9.0.4",
-				"@natlibfi/sru-client": "^5.0.4",
+				"@natlibfi/melinda-backend-commons": "^2.2.1",
+				"@natlibfi/melinda-commons": "^13.0.5",
+				"amqplib": ">=0.10.3 <1.0.0",
 				"debug": "^4.3.4",
-				"deep-eql": "^4.1.3",
 				"http-status": "^1.6.2",
 				"moment": "^2.29.4",
-				"nock": "^13.3.0",
-				"node-fetch": "^2.6.8"
+				"node-fetch": "^2.6.12",
+				"rimraf": "^3.0.2",
+				"uuid": "^9.0.0",
+				"yargs": "^17.7.2"
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@natlibfi/melinda-record-import-commons/node_modules/@natlibfi/sru-client": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-5.0.4.tgz",
-			"integrity": "sha512-QY4QOlmSeLYR7k/lYqEOGfpT4aEemfXWfw5DrzuR3D6vdyCOjtra3swGRMS2hG0P8/nTGBVQ/KrosmPc7l8n0A==",
-			"dependencies": {
-				"debug": "^4.3.4",
-				"http-status": "^1.5.2",
-				"node-fetch": "^2.6.7",
-				"xml2js": ">=0.4.23 <1.0.0"
-			},
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/@natlibfi/melinda-record-import-commons/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@natlibfi/sru-client": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.3.tgz",
-			"integrity": "sha512-DkgdP3uvlS4CcRnZncf/iWQeOlYUZmbKtFpOSFs1qe0K4H2yEdt8+mbJM4ckOW+Fk3zLPEXqmfyvwFvc70TswA==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.4.tgz",
+			"integrity": "sha512-xQme23HWtY+aDz/axAWP/0Tx6twY0HIS/5gNurD3uM3pYKIlvSXAjaK+t7VesiBbZnKvkFkngJAa66y+ESQ8Hg==",
 			"dependencies": {
 				"debug": "^4.3.4",
 				"http-status": "^1.6.2",
-				"node-fetch": "^2.6.9",
-				"xml2js": ">=0.5.0 <1.0.0"
+				"node-fetch": "^2.6.12",
+				"xml2js": ">=0.6.2 <1.0.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2363,14 +2302,6 @@
 			"dev": true,
 			"dependencies": {
 				"eslint-scope": "5.1.1"
-			}
-		},
-		"node_modules/@nicolo-ribaudo/semver-v6": {
-			"version": "6.3.3",
-			"resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
-			"integrity": "sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==",
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -2509,6 +2440,39 @@
 				}
 			}
 		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
 		"node_modules/@typescript-eslint/utils": {
 			"version": "5.62.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
@@ -2534,6 +2498,39 @@
 			"peerDependencies": {
 				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "5.62.0",
@@ -2565,9 +2562,9 @@
 			}
 		},
 		"node_modules/@xmldom/xmldom": {
-			"version": "0.8.8",
-			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.8.tgz",
-			"integrity": "sha512-0LNz4EY8B/8xXY86wMrQ4tz6zEHZv9ehFMJPm8u2gq5lQ71cfRKdaKyxfJAx5aUoyzx0qzgURblTisPGgz3d+Q==",
+			"version": "0.8.10",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+			"integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
 			"engines": {
 				"node": ">=10.0.0"
 			}
@@ -2748,6 +2745,26 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/arraybuffer.prototype.slice": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.1.tgz",
+			"integrity": "sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==",
+			"dev": true,
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.0",
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"get-intrinsic": "^1.2.1",
+				"is-array-buffer": "^3.0.2",
+				"is-shared-array-buffer": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -2775,42 +2792,42 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.4.tgz",
-			"integrity": "sha512-9WeK9snM1BfxB38goUEv2FLnA6ja07UMfazFHzCXUb3NyDZAwfXvQiURQ6guTTMeHcOsdknULm1PDhs4uWtKyA==",
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.5.tgz",
+			"integrity": "sha512-19hwUH5FKl49JEsvyTcoHakh6BE0wgXLLptIyKZ3PijHc/Ci521wygORCUCCred+E/twuqRyAkE02BAWPmsHOg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.22.6",
-				"@babel/helper-define-polyfill-provider": "^0.4.1",
-				"@nicolo-ribaudo/semver-v6": "^6.3.3"
+				"@babel/helper-define-polyfill-provider": "^0.4.2",
+				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
+				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.2.tgz",
-			"integrity": "sha512-Cid+Jv1BrY9ReW9lIfNlNpsI53N+FN7gE+f73zLAUbr9C52W4gKLWSByx47pfDJsEysojKArqOtOKZSVIIUTuQ==",
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.3.tgz",
+			"integrity": "sha512-z41XaniZL26WLrvjy7soabMXrfPWARN25PZoriDEiLMxAp50AUW3t35BGQUMg5xK3UrpVTtagIDklxYa+MhiNA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.4.1",
+				"@babel/helper-define-polyfill-provider": "^0.4.2",
 				"core-js-compat": "^3.31.0"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
+				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.1.tgz",
-			"integrity": "sha512-L8OyySuI6OSQ5hFy9O+7zFjyr4WhAfRjLIOkhQGYl+emwJkd/S4XXT1JpfrgR1jrQ1NcGiOh+yAdGlF8pnC3Jw==",
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.2.tgz",
+			"integrity": "sha512-tAlOptU0Xj34V1Y2PNTL4Y0FOJMDB6bZmoW39FeCQIhigGLkqu3Fj6uiXpxIf6Ij274ENdYx64y6Au+ZKlb1IA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.4.1"
+				"@babel/helper-define-polyfill-provider": "^0.4.2"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
+				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/babel-plugin-rewire": {
@@ -2939,15 +2956,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/caching-transform/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
 		"node_modules/call-bind": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -2980,9 +2988,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001515",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-			"integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
+			"version": "1.0.30001517",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
+			"integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3372,9 +3380,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.457",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.457.tgz",
-			"integrity": "sha512-/g3UyNDmDd6ebeWapmAoiyy+Sy2HyJ+/X8KyvNeHfKRFfHaA2W8oF5fxD5F3tjBDcjpwo0iek6YNgxNXDBoEtA=="
+			"version": "1.4.473",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.473.tgz",
+			"integrity": "sha512-aVfC8+440vGfl06l8HKKn8/PD5jRfSnLkTTD65EFvU46igbpQRri1gxSzW9/+TeUlwYzrXk1sw867T96zlyECA=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -3400,18 +3408,19 @@
 			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
 		},
 		"node_modules/es-abstract": {
-			"version": "1.21.2",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
-			"integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
+			"version": "1.22.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
+			"integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
 			"dev": true,
 			"dependencies": {
 				"array-buffer-byte-length": "^1.0.0",
+				"arraybuffer.prototype.slice": "^1.0.1",
 				"available-typed-arrays": "^1.0.5",
 				"call-bind": "^1.0.2",
 				"es-set-tostringtag": "^2.0.1",
 				"es-to-primitive": "^1.2.1",
 				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.2.0",
+				"get-intrinsic": "^1.2.1",
 				"get-symbol-description": "^1.0.0",
 				"globalthis": "^1.0.3",
 				"gopd": "^1.0.1",
@@ -3431,14 +3440,18 @@
 				"object-inspect": "^1.12.3",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.4",
-				"regexp.prototype.flags": "^1.4.3",
+				"regexp.prototype.flags": "^1.5.0",
+				"safe-array-concat": "^1.0.0",
 				"safe-regex-test": "^1.0.0",
 				"string.prototype.trim": "^1.2.7",
 				"string.prototype.trimend": "^1.0.6",
 				"string.prototype.trimstart": "^1.0.6",
+				"typed-array-buffer": "^1.0.0",
+				"typed-array-byte-length": "^1.0.0",
+				"typed-array-byte-offset": "^1.0.0",
 				"typed-array-length": "^1.0.4",
 				"unbox-primitive": "^1.0.2",
-				"which-typed-array": "^1.1.9"
+				"which-typed-array": "^1.1.10"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -3507,27 +3520,27 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.44.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-			"integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+			"version": "8.46.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
+			"integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
-				"@eslint-community/regexpp": "^4.4.0",
-				"@eslint/eslintrc": "^2.1.0",
-				"@eslint/js": "8.44.0",
+				"@eslint-community/regexpp": "^4.6.1",
+				"@eslint/eslintrc": "^2.1.1",
+				"@eslint/js": "^8.46.0",
 				"@humanwhocodes/config-array": "^0.11.10",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
-				"ajv": "^6.10.0",
+				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.2.0",
-				"eslint-visitor-keys": "^3.4.1",
-				"espree": "^9.6.0",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.2",
+				"espree": "^9.6.1",
 				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -3537,7 +3550,6 @@
 				"globals": "^13.19.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
-				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"is-path-inside": "^3.0.3",
@@ -3549,7 +3561,6 @@
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
-				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
 			},
 			"bin": {
@@ -3605,6 +3616,39 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/eslint-plugin-functional/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-plugin-functional/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-plugin-functional/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"node_modules/eslint-scope": {
 			"version": "5.1.1",
@@ -3690,9 +3734,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/eslint-scope": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-			"integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
@@ -3706,9 +3750,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/eslint-visitor-keys": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-			"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
+			"integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3787,9 +3831,9 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-			"integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.9.0",
@@ -3804,9 +3848,9 @@
 			}
 		},
 		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-			"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
+			"integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3910,9 +3954,9 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-			"integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+			"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -4804,16 +4848,12 @@
 			}
 		},
 		"node_modules/is-typed-array": {
-			"version": "1.1.10",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-			"integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+			"integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
 			"dev": true,
 			"dependencies": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.0"
+				"which-typed-array": "^1.1.11"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -4929,15 +4969,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/istanbul-lib-instrument/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
 		"node_modules/istanbul-lib-processinfo": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
@@ -4965,17 +4996,17 @@
 			}
 		},
 		"node_modules/istanbul-lib-report": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-			"integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
 			"dev": true,
 			"dependencies": {
 				"istanbul-lib-coverage": "^3.0.0",
-				"make-dir": "^3.0.0",
+				"make-dir": "^4.0.0",
 				"supports-color": "^7.1.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
 			}
 		},
 		"node_modules/istanbul-lib-report/node_modules/has-flag": {
@@ -4987,28 +5018,46 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/istanbul-lib-report/node_modules/make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+		"node_modules/istanbul-lib-report/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dev": true,
 			"dependencies": {
-				"semver": "^6.0.0"
+				"yallist": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-report/node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/istanbul-lib-report/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
 			"bin": {
 				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/istanbul-lib-report/node_modules/supports-color": {
@@ -5022,6 +5071,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/istanbul-lib-report/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"node_modules/istanbul-lib-source-maps": {
 			"version": "4.0.1",
@@ -5038,9 +5093,9 @@
 			}
 		},
 		"node_modules/istanbul-reports": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
-			"integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+			"integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
 			"dev": true,
 			"dependencies": {
 				"html-escaper": "^2.0.0",
@@ -5553,9 +5608,9 @@
 			"dev": true
 		},
 		"node_modules/nock": {
-			"version": "13.3.1",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-13.3.1.tgz",
-			"integrity": "sha512-vHnopocZuI93p2ccivFyGuUfzjq2fxNyNurp7816mlT5V5HF4SzXu8lvLrVzBbNqzs+ODooZ6OksuSUNM7Njkw==",
+			"version": "13.3.2",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-13.3.2.tgz",
+			"integrity": "sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==",
 			"dependencies": {
 				"debug": "^4.1.0",
 				"json-stringify-safe": "^5.0.1",
@@ -5657,6 +5712,39 @@
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
+		},
+		"node_modules/nodemon/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/nodemon/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/nodemon/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"node_modules/nopt": {
 			"version": "1.0.10",
@@ -5870,15 +5958,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/nyc/node_modules/wrap-ansi": {
@@ -6619,37 +6698,12 @@
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"bin": {
 				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
-		},
-		"node_modules/semver/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/semver/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.0",
@@ -6738,6 +6792,39 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/simple-update-notifier/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/simple-update-notifier/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/simple-update-notifier/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
 		"node_modules/slash": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -6794,15 +6881,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/spawn-wrap/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/sprintf-js": {
@@ -7069,6 +7147,57 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/typed-array-buffer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
+			"integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.2.1",
+				"is-typed-array": "^1.1.10"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/typed-array-byte-length": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
+			"integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"for-each": "^0.3.3",
+				"has-proto": "^1.0.1",
+				"is-typed-array": "^1.1.10"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typed-array-byte-offset": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
+			"integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
+			"dev": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.5",
+				"call-bind": "^1.0.2",
+				"for-each": "^0.3.3",
+				"has-proto": "^1.0.1",
+				"is-typed-array": "^1.1.10"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/typed-array-length": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
@@ -7313,17 +7442,16 @@
 			"dev": true
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.10",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.10.tgz",
-			"integrity": "sha512-uxoA5vLUfRPdjCuJ1h5LlYdmTLbYfums398v3WLkM+i/Wltl2/XyZpQWKbN++ck5L64SR/grOHqtXCUKmlZPNA==",
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+			"integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
 			"dev": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.5",
 				"call-bind": "^1.0.2",
 				"for-each": "^0.3.3",
 				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.0",
-				"is-typed-array": "^1.1.10"
+				"has-tostringtag": "^1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -7516,9 +7644,9 @@
 			}
 		},
 		"node_modules/xml2js": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
-			"integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
 			"dependencies": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-record-import-transformer-helmet.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "1.0.1-alpha.2",
+	"version": "1.0.1-alpha.3",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-record-import-transformer-helmet.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "1.0.1-alpha.3",
+	"version": "1.0.1-alpha.4",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@natlibfi/marc-record-validators-melinda": "^10.9.3",
 		"@natlibfi/melinda-backend-commons": "^2.2.1",
 		"@natlibfi/melinda-commons": "^13.0.5",
-		"@natlibfi/melinda-record-import-commons": "^10.1.6",
+		"@natlibfi/melinda-record-import-commons": "^10.1.7",
 		"amqplib": ">=0.10.3 <1.0.0",
 		"moment": "^2.29.4",
 		"stream-chain": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"watch:dev": "cross-env DEBUG=1 nodemon -w src --exec 'babel-node src/index.js'"
 	},
 	"dependencies": {
-		"@babel/runtime": "latest",
+		"@babel/runtime": "7.22.10",
 		"@natlibfi/marc-record": "^7.2.4",
 		"@natlibfi/marc-record-validate": "^8.0.1",
 		"@natlibfi/marc-record-validators-melinda": "^10.9.3",
@@ -46,13 +46,13 @@
 		"stream-json": "^1.8.0"
 	},
 	"devDependencies": {
-		"@babel/cli": "^7.22.9",
-		"@babel/core": "latest",
-		"@babel/eslint-parser": "latest",
-		"@babel/node": "^7.22.6",
-		"@babel/preset-env": "latest",
+		"@babel/cli": "^7.22.10",
+		"@babel/core": "7.22.10",
+		"@babel/eslint-parser": "7.22.10",
+		"@babel/node": "^7.22.10",
+		"@babel/preset-env": "7.22.10",
 		"@babel/register": "^7.22.5",
-		"@natlibfi/eslint-config-melinda-backend": "^3.0.0",
+		"@natlibfi/eslint-config-melinda-backend": "^3.0.1",
 		"@natlibfi/fixugen": "^2.0.1",
 		"@natlibfi/fixura": "^3.0.1",
 		"babel-plugin-rewire": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
 		"url": "git@github.com:natlibfi/melinda-record-import-transformer-helmet.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "1.0.0",
+	"version": "1.0.1-alpha.2",
 	"main": "./dist/index.js",
 	"engines": {
-		"node": ">=14"
+		"node": ">=18"
 	},
 	"scripts": {
 		"start": "node dist/index.js",
@@ -34,32 +34,32 @@
 	},
 	"dependencies": {
 		"@babel/runtime": "latest",
-		"@natlibfi/marc-record": "^7.2.2",
-		"@natlibfi/marc-record-validate": "^8.0.0",
-		"@natlibfi/marc-record-validators-melinda": "^10.9.2",
-		"@natlibfi/melinda-backend-commons": "^2.2.0",
-		"@natlibfi/melinda-commons": "^13.0.4",
-		"@natlibfi/melinda-record-import-commons": "^10.1.6-alpha.4",
+		"@natlibfi/marc-record": "^7.2.4",
+		"@natlibfi/marc-record-validate": "^8.0.1",
+		"@natlibfi/marc-record-validators-melinda": "^10.9.3",
+		"@natlibfi/melinda-backend-commons": "^2.2.1",
+		"@natlibfi/melinda-commons": "^13.0.5",
+		"@natlibfi/melinda-record-import-commons": "^10.1.6",
 		"amqplib": ">=0.10.3 <1.0.0",
 		"moment": "^2.29.4",
 		"stream-chain": "^2.2.5",
-		"stream-json": "^1.7.5"
+		"stream-json": "^1.8.0"
 	},
 	"devDependencies": {
-		"@babel/cli": "^7.22.6",
+		"@babel/cli": "^7.22.9",
 		"@babel/core": "latest",
 		"@babel/eslint-parser": "latest",
 		"@babel/node": "^7.22.6",
 		"@babel/preset-env": "latest",
 		"@babel/register": "^7.22.5",
 		"@natlibfi/eslint-config-melinda-backend": "^3.0.0",
-		"@natlibfi/fixugen": "^2.0.0",
-		"@natlibfi/fixura": "^3.0.0",
+		"@natlibfi/fixugen": "^2.0.1",
+		"@natlibfi/fixura": "^3.0.1",
 		"babel-plugin-rewire": "^1.2.0",
-		"chai": "^4.3.6",
+		"chai": "^4.3.7",
 		"chai-as-promised": "^7.1.1",
 		"cross-env": "^7.0.3",
-		"eslint": "^8.44.0",
+		"eslint": "^8.46.0",
 		"mocha": "^10.2.0",
 		"nodemon": "^3.0.1",
 		"nyc": "^15.1.0"


### PR DESCRIPTION
* Bump @natlibfi/melinda-record-import-commons (#93)
* Bump @natlibfi/melinda-commons from 13.0.4 to 13.0.5 (#92)
* Bump @natlibfi/melinda-backend-commons from 2.2.0 to 2.2.1 (#91)
* Bump @natlibfi/marc-record-validators-melinda from 10.9.2 to 10.9.3 (#90)
* Bump docker/build-push-action from 3 to 4 (#63)

* Update deps
* Update node-test: v20.x
* Update node version in package.json

* 1.0.1-alpha.2