### PR TITLE
Dependency & Maintenance update (#134)

### DIFF
--- a/.github/workflows/melinda-node-tests.yml
+++ b/.github/workflows/melinda-node-tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 19.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -75,6 +75,7 @@ jobs:
     name: Quay.io image builder & publisher
     needs: [build-node-versions, njsscan]
     runs-on: ubuntu-latest
+    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
 
     steps:
       - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-record-import-transformer-helmet",
-	"version": "1.0.2-alpha.5",
+	"version": "1.0.3-alpha.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-record-import-transformer-helmet",
-			"version": "1.0.2-alpha.5",
+			"version": "1.0.3-alpha.3",
 			"license": "AGPL-3.0+",
 			"dependencies": {
 				"@babel/runtime": "^7.23.4",
@@ -108,9 +108,9 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.4.tgz",
-			"integrity": "sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
 			"dependencies": {
 				"@babel/highlight": "^7.23.4",
 				"chalk": "^2.4.2"
@@ -120,28 +120,28 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
-			"integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+			"integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
-			"integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
+			"integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.22.13",
-				"@babel/generator": "^7.23.3",
-				"@babel/helper-compilation-targets": "^7.22.15",
+				"@babel/code-frame": "^7.23.5",
+				"@babel/generator": "^7.23.6",
+				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helpers": "^7.23.2",
-				"@babel/parser": "^7.23.3",
+				"@babel/helpers": "^7.23.7",
+				"@babel/parser": "^7.23.6",
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.3",
-				"@babel/types": "^7.23.3",
+				"@babel/traverse": "^7.23.7",
+				"@babel/types": "^7.23.6",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -175,11 +175,11 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.4.tgz",
-			"integrity": "sha512-esuS49Cga3HcThFNebGhlgsrVLkvhqvYDTzgjfFFlHJcIfLe5jFmRRfCQ1KuBfc4Jrtn3ndLgKWAKjBE+IraYQ==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+			"integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
 			"dependencies": {
-				"@babel/types": "^7.23.4",
+				"@babel/types": "^7.23.6",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -213,13 +213,13 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-			"integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+			"integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
 			"dependencies": {
-				"@babel/compat-data": "^7.22.9",
-				"@babel/helper-validator-option": "^7.22.15",
-				"browserslist": "^4.21.9",
+				"@babel/compat-data": "^7.23.5",
+				"@babel/helper-validator-option": "^7.23.5",
+				"browserslist": "^4.22.2",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
 			},
@@ -268,9 +268,9 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.3.tgz",
-			"integrity": "sha512-WBrLmuPP47n7PNwsZ57pqam6G/RGo1vw/87b0Blc53tZNGZ4x7YvZ6HgQe2vo1W/FR20OgjeZuGXzudPiXHFug==",
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.4.tgz",
+			"integrity": "sha512-QcJMILQCu2jm5TFPGA3lCpJJTeEP+mqeXooG/NZbg/h5FTFi6V0+99ahlRsW8/kRLyb24LZVCCiclDedhLKcBA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-compilation-targets": "^7.22.6",
@@ -461,9 +461,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-			"integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+			"integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -483,13 +483,13 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.4.tgz",
-			"integrity": "sha512-HfcMizYz10cr3h29VqyfGL6ZWIjTwWfvYBMsBVGwpcbhNGe3wQ1ZXZRPzZoAHhd9OqHadHqjQ89iVKINXnbzuw==",
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
+			"integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
 			"dependencies": {
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.4",
-				"@babel/types": "^7.23.4"
+				"@babel/traverse": "^7.23.7",
+				"@babel/types": "^7.23.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -509,9 +509,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.4.tgz",
-			"integrity": "sha512-vf3Xna6UEprW+7t6EtOmFpHNAuxw3xqPZghy+brsnusscJRW5BMUzzHZc5ICjULee81WeUV2jjakG09MDglJXQ==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+			"integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -552,9 +552,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.23.3.tgz",
-			"integrity": "sha512-XaJak1qcityzrX0/IU5nKHb34VaibwP3saKqG6a/tppelgllOH13LUann4ZCIBcVOeE6H18K4Vx9QKkVww3z/w==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.23.7.tgz",
+			"integrity": "sha512-LlRT7HgaifEpQA1ZgLVOIJZZFVPWN5iReq/7/JixwBtwcoeVGDBD53ZV28rrsLYOZs1Y/EHhA8N/Z6aazHR8cw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
@@ -830,9 +830,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.4.tgz",
-			"integrity": "sha512-efdkfPhHYTtn0G6n2ddrESE91fgXxjlqLsnUtPWnJs4a4mZIbUaK7ffqKIIUKXSHwcDvaCVX6GXkaJJFqtX7jw==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.7.tgz",
+			"integrity": "sha512-PdxEpL71bJp1byMG0va5gwQcXHxuEYC/BgI/e88mGTtohbZN28O5Yit0Plkkm/dBzCF/BxmbNcses1RH1T+urA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
@@ -928,16 +928,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.3.tgz",
-			"integrity": "sha512-FGEQmugvAEu2QtgtU0uTASXevfLMFfBeVCIIdcQhn/uBQsMTjBajdnAtanQlOcuihWh10PZ7+HWvc7NtBwP74w==",
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.8.tgz",
+			"integrity": "sha512-yAYslGsY1bX6Knmg46RjiCiNSwJKv2IUC8qOdYKqMMr0491SXFhcHqOdRDeCRohOOIzwN/90C6mQ9qAKgrP7dg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-compilation-targets": "^7.22.15",
+				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-environment-visitor": "^7.22.20",
 				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-optimise-call-expression": "^7.22.5",
 				"@babel/helper-plugin-utils": "^7.22.5",
 				"@babel/helper-replace-supers": "^7.22.20",
 				"@babel/helper-split-export-declaration": "^7.22.6",
@@ -1061,12 +1060,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-for-of": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.23.3.tgz",
-			"integrity": "sha512-X8jSm8X1CMwxmK878qsUGJRmbysKNbdpTv/O1/v0LuY/ZkZrng5WYiekYSdg9m09OTmDDUWeEDsTE+17WYbAZw==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.23.6.tgz",
+			"integrity": "sha512-aYH4ytZ0qSuBbpfhuofbg/e96oQ7U2w1Aw/UQmKT+1l39uEhUPoFS3fHevDc1G0OvewyDudfMKY1OulczHzWIw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1448,16 +1448,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.4.tgz",
-			"integrity": "sha512-ITwqpb6V4btwUG0YJR82o2QvmWrLgDnx/p2A3CTPYGaRgULkDiC0DRA2C4jlRB9uXGUEfaSS/IGHfVW+ohzYDw==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.7.tgz",
+			"integrity": "sha512-fa0hnfmiXc9fq/weK34MUV0drz2pOL/vfKWvN7Qw127hiUPabFCUMgAbYWcchRzMJit4o5ARsK/s+5h0249pLw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.22.15",
 				"@babel/helper-plugin-utils": "^7.22.5",
-				"babel-plugin-polyfill-corejs2": "^0.4.6",
-				"babel-plugin-polyfill-corejs3": "^0.8.5",
-				"babel-plugin-polyfill-regenerator": "^0.5.3",
+				"babel-plugin-polyfill-corejs2": "^0.4.7",
+				"babel-plugin-polyfill-corejs3": "^0.8.7",
+				"babel-plugin-polyfill-regenerator": "^0.5.4",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -1607,18 +1607,18 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.3.tgz",
-			"integrity": "sha512-ovzGc2uuyNfNAs/jyjIGxS8arOHS5FENZaNn4rtE7UdKMMkqHCvboHfcuhWLZNX5cB44QfcGNWjaevxMzzMf+Q==",
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.8.tgz",
+			"integrity": "sha512-lFlpmkApLkEP6woIKprO6DO60RImpatTQKtz4sUcDjVcK8M8mQ4sZsuxaTMNOZf0sqAq/ReYW1ZBHnOQwKpLWA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.23.3",
-				"@babel/helper-compilation-targets": "^7.22.15",
+				"@babel/compat-data": "^7.23.5",
+				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-validator-option": "^7.22.15",
+				"@babel/helper-validator-option": "^7.23.5",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.23.3",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.23.3",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.23.7",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-class-properties": "^7.12.13",
@@ -1639,25 +1639,25 @@
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.23.3",
-				"@babel/plugin-transform-async-generator-functions": "^7.23.3",
+				"@babel/plugin-transform-async-generator-functions": "^7.23.7",
 				"@babel/plugin-transform-async-to-generator": "^7.23.3",
 				"@babel/plugin-transform-block-scoped-functions": "^7.23.3",
-				"@babel/plugin-transform-block-scoping": "^7.23.3",
+				"@babel/plugin-transform-block-scoping": "^7.23.4",
 				"@babel/plugin-transform-class-properties": "^7.23.3",
-				"@babel/plugin-transform-class-static-block": "^7.23.3",
-				"@babel/plugin-transform-classes": "^7.23.3",
+				"@babel/plugin-transform-class-static-block": "^7.23.4",
+				"@babel/plugin-transform-classes": "^7.23.8",
 				"@babel/plugin-transform-computed-properties": "^7.23.3",
 				"@babel/plugin-transform-destructuring": "^7.23.3",
 				"@babel/plugin-transform-dotall-regex": "^7.23.3",
 				"@babel/plugin-transform-duplicate-keys": "^7.23.3",
-				"@babel/plugin-transform-dynamic-import": "^7.23.3",
+				"@babel/plugin-transform-dynamic-import": "^7.23.4",
 				"@babel/plugin-transform-exponentiation-operator": "^7.23.3",
-				"@babel/plugin-transform-export-namespace-from": "^7.23.3",
-				"@babel/plugin-transform-for-of": "^7.23.3",
+				"@babel/plugin-transform-export-namespace-from": "^7.23.4",
+				"@babel/plugin-transform-for-of": "^7.23.6",
 				"@babel/plugin-transform-function-name": "^7.23.3",
-				"@babel/plugin-transform-json-strings": "^7.23.3",
+				"@babel/plugin-transform-json-strings": "^7.23.4",
 				"@babel/plugin-transform-literals": "^7.23.3",
-				"@babel/plugin-transform-logical-assignment-operators": "^7.23.3",
+				"@babel/plugin-transform-logical-assignment-operators": "^7.23.4",
 				"@babel/plugin-transform-member-expression-literals": "^7.23.3",
 				"@babel/plugin-transform-modules-amd": "^7.23.3",
 				"@babel/plugin-transform-modules-commonjs": "^7.23.3",
@@ -1665,15 +1665,15 @@
 				"@babel/plugin-transform-modules-umd": "^7.23.3",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
 				"@babel/plugin-transform-new-target": "^7.23.3",
-				"@babel/plugin-transform-nullish-coalescing-operator": "^7.23.3",
-				"@babel/plugin-transform-numeric-separator": "^7.23.3",
-				"@babel/plugin-transform-object-rest-spread": "^7.23.3",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^7.23.4",
+				"@babel/plugin-transform-numeric-separator": "^7.23.4",
+				"@babel/plugin-transform-object-rest-spread": "^7.23.4",
 				"@babel/plugin-transform-object-super": "^7.23.3",
-				"@babel/plugin-transform-optional-catch-binding": "^7.23.3",
-				"@babel/plugin-transform-optional-chaining": "^7.23.3",
+				"@babel/plugin-transform-optional-catch-binding": "^7.23.4",
+				"@babel/plugin-transform-optional-chaining": "^7.23.4",
 				"@babel/plugin-transform-parameters": "^7.23.3",
 				"@babel/plugin-transform-private-methods": "^7.23.3",
-				"@babel/plugin-transform-private-property-in-object": "^7.23.3",
+				"@babel/plugin-transform-private-property-in-object": "^7.23.4",
 				"@babel/plugin-transform-property-literals": "^7.23.3",
 				"@babel/plugin-transform-regenerator": "^7.23.3",
 				"@babel/plugin-transform-reserved-words": "^7.23.3",
@@ -1687,9 +1687,9 @@
 				"@babel/plugin-transform-unicode-regex": "^7.23.3",
 				"@babel/plugin-transform-unicode-sets-regex": "^7.23.3",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"babel-plugin-polyfill-corejs2": "^0.4.6",
-				"babel-plugin-polyfill-corejs3": "^0.8.5",
-				"babel-plugin-polyfill-regenerator": "^0.5.3",
+				"babel-plugin-polyfill-corejs2": "^0.4.7",
+				"babel-plugin-polyfill-corejs3": "^0.8.7",
+				"babel-plugin-polyfill-regenerator": "^0.5.4",
 				"core-js-compat": "^3.31.0",
 				"semver": "^6.3.1"
 			},
@@ -1715,14 +1715,14 @@
 			}
 		},
 		"node_modules/@babel/register": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.22.15.tgz",
-			"integrity": "sha512-V3Q3EqoQdn65RCgTLwauZaTfd1ShhwPmbBv+1dkZV/HpCGMKVyn6oFcRlI7RaKqiDQjX2Qd3AuoEguBgdjIKlg==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.23.7.tgz",
+			"integrity": "sha512-EjJeB6+kvpk+Y5DAkEAmbOBEFkh9OASx0huoEkqYTFxAZHzOAX2Oh5uwAUuL2rUddqfM0SA+KPXV2TbzoZ2kvQ==",
 			"dependencies": {
 				"clone-deep": "^4.0.1",
 				"find-cache-dir": "^2.0.0",
 				"make-dir": "^2.1.0",
-				"pirates": "^4.0.5",
+				"pirates": "^4.0.6",
 				"source-map-support": "^0.5.16"
 			},
 			"engines": {
@@ -1739,9 +1739,9 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.4.tgz",
-			"integrity": "sha512-2Yv65nlWnWlSpe3fXEyX5i7fx5kIKo4Qbcj+hMO0odwaneFjfXw5fdum+4yL20O0QiaHpia0cYQ9xpNMqrBwHg==",
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
+			"integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -1763,19 +1763,19 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.4.tgz",
-			"integrity": "sha512-IYM8wSUwunWTB6tFC2dkKZhxbIjHoWemdK+3f8/wq8aKhbUscxD5MX72ubd90fxvFknaLPeGw5ycU84V1obHJg==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+			"integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
 			"dependencies": {
-				"@babel/code-frame": "^7.23.4",
-				"@babel/generator": "^7.23.4",
+				"@babel/code-frame": "^7.23.5",
+				"@babel/generator": "^7.23.6",
 				"@babel/helper-environment-visitor": "^7.22.20",
 				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.4",
-				"@babel/types": "^7.23.4",
-				"debug": "^4.1.0",
+				"@babel/parser": "^7.23.6",
+				"@babel/types": "^7.23.6",
+				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -1783,9 +1783,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.4.tgz",
-			"integrity": "sha512-7uIFwVYpoplT5jp/kVv6EF93VaJ8H+Yn5IczYiaAi98ajzjfoZfslet/e0sLh+wVBjb2qqIut1b0S26VSafsSQ==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+			"integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.23.4",
 				"@babel/helper-validator-identifier": "^7.22.20",
@@ -1850,9 +1850,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
-			"integrity": "sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
@@ -1879,9 +1879,9 @@
 			"dev": true
 		},
 		"node_modules/@eslint/eslintrc/node_modules/globals": {
-			"version": "13.23.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-			"integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -1918,9 +1918,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.54.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.54.0.tgz",
-			"integrity": "sha512-ut5V+D+fOoWPgGGNj83GGjnntO39xDy6DWxO0wb7Jp3DcMX0TfIqdzHF85VTQkerdyGmuuMD9AKAo5KiNlf/AQ==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+			"integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2046,18 +2046,18 @@
 			}
 		},
 		"node_modules/@natlibfi/fixugen": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen/-/fixugen-2.0.2.tgz",
-			"integrity": "sha512-xoGqYOheQZwyAljqQe+OKiYGX1W08AqZJJILrUJlhY9d0sYNAg0v9MLAVlrLBf1v04WEjQPN/LHwGlZtf6D50A==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen/-/fixugen-2.0.4.tgz",
+			"integrity": "sha512-GT/80Mv1vepF0WRaLpiA/wpUkjnYWVJ6izsqp9xXJqwX8JaO50O/fyQcZyxkE2zHWwiUsJW3PqD22ii7G/dgQA==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@natlibfi/fixura": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixura/-/fixura-3.0.2.tgz",
-			"integrity": "sha512-LJKe3I8gjZ2ebGI5U8X4mr0jy3w9oLA+Ghz9t0aHVfj3EOYK5JO+ZQn9/28ls8LEeuWlC4PD4+zzJu0Sz3Ri2g==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/fixura/-/fixura-3.0.4.tgz",
+			"integrity": "sha512-rJMOCmvlNNNlxYU0gFpuRLUEH3/sPsZQK3F2+v/ldjZKBRIaRHlBb8IXGyw/Loekr7+TAfbI5wFieuvO+2+0UQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/register": "^7.22.15"
@@ -2072,9 +2072,9 @@
 			"integrity": "sha512-0fpHpdiCfdpifsHGeAKNhaTm2l1Lljjf5iSzowYgppLaTEw3Rgm+Bo3+6euatRI6sWK0xLHLpZU0hSCUc2yvJg=="
 		},
 		"node_modules/@natlibfi/marc-record": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-8.0.0.tgz",
-			"integrity": "sha512-dU/5tt0zXe2ynuugNRQybKhn3tCvL7ClXmOEdFNY7fR+bStqFuEI+gq2gWSzaT2lywhIAByTo1Y5m+uY09eEnA==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-8.1.0.tgz",
+			"integrity": "sha512-kezWNVlOsBNdETT5xvoVU5d1308duKg/UebhXMavjDPbNO0IdoWRcFKUvS8ThV0hiVQ7ErlxK5DwnSJY25nODw==",
 			"dependencies": {
 				"debug": "^4.3.4",
 				"jsonschema": "^1.4.1"
@@ -2102,42 +2102,30 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validate": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validate/-/marc-record-validate-8.0.3.tgz",
-			"integrity": "sha512-kiqYWGaQwqau2dCL4aSbPHBtleDHpcON6GYpXOgLsGysCcpMQ4f1Ik3aLdmMUyEAZ5i6zlDkGtO0D2BW0Jskng==",
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validate/-/marc-record-validate-8.0.5.tgz",
+			"integrity": "sha512-AUscqIZxJi/1ho6/fDTC22CcjP8PXZhHrBOYneb38Gwl3i2q8EGC29nMnVtvI/aF80nWFG0kfAm2xCCYbkgQBA==",
 			"dependencies": {
-				"@babel/runtime": "^7.23.2",
-				"@natlibfi/marc-record": "^7.3.1"
+				"@babel/runtime": "^7.23.6",
+				"@natlibfi/marc-record": "^8.0.2"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@natlibfi/marc-record-validate/node_modules/@natlibfi/marc-record": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-7.3.1.tgz",
-			"integrity": "sha512-pN/7sHX+VeLhZNpEwp+RQAA4s2wcvab7axdmMpD81yVMBmLvruVMAiMyBXHAq4O39fTs5s/3o8FTme0dpctGzQ==",
-			"dependencies": {
-				"debug": "^4.3.4",
-				"jsonschema": "^1.4.1"
-			},
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "10.15.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-10.15.1.tgz",
-			"integrity": "sha512-Na6tiO9u5gOuuqxqmmDSsQ9/2YxJick1sajcLBBzstdBS2LAMHdbRO4up1EpKx5fBl1CA+4e4UOZbzHUKyopBg==",
+			"version": "10.15.5",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-10.15.5.tgz",
+			"integrity": "sha512-brLT0G2xWI7Y9xQEyoBLJ9YwaXqXH6F9AbZaxi/oS6nMKk/Vp4JQfUtTrEY0v1IocvtsJV1DlBuF0zAVs5BaZA==",
 			"dependencies": {
-				"@babel/register": "^7.22.15",
+				"@babel/register": "^7.23.7",
 				"@natlibfi/issn-verify": "^1.0.3",
-				"@natlibfi/marc-record": "^8.0.0",
-				"@natlibfi/marc-record-validate": "^8.0.3",
+				"@natlibfi/marc-record": "^8.1.0",
+				"@natlibfi/marc-record-validate": "^8.0.5",
 				"cld3-asm": "^3.1.1",
 				"clone": "^2.1.2",
 				"debug": "^4.3.4",
-				"isbn3": "^1.1.43",
+				"isbn3": "^1.1.44",
 				"langs": "^2.0.0",
 				"node-fetch": "^2.7.0",
 				"xml2js": "^0.6.2"
@@ -2146,13 +2134,13 @@
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@natlibfi/marc-record-validate": "^8.0.3"
+				"@natlibfi/marc-record-validate": "^8.0.5"
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.2.2.tgz",
-			"integrity": "sha512-zjN5mOEozY+MQ13meQS3rYQ/ZHxBsAceq5+AKZufHBPtM7N+2IW+8Jxhb5OUwvhF7sAAEThafCDpCKkdX/N3xg==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-2.2.6.tgz",
+			"integrity": "sha512-BlAfjt1VH789dqmvMzKqGG8Gwj2TCkMGTiQ9FOIxbmWg1Wb6C6/OJCDSshB0JW7XNMMiVS4ZkOfDrOt4q1kmgA==",
 			"dependencies": {
 				"base64-url": "^2.3.3",
 				"debug": "^4.3.4",
@@ -2171,18 +2159,18 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "13.0.8",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.8.tgz",
-			"integrity": "sha512-jx6rlt4q94WDxdn7vqXMorFD68dwowMaQQ3cFH4qpv5xq9uQmJZhBBFoanmy5oaNeg6W0DfqhW+aheMM7xUt3A==",
+			"version": "13.0.11",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-13.0.11.tgz",
+			"integrity": "sha512-IQRpKfSMwfNcOldOnoyWGxAs8v6TPDNVUa/mOq3eh13aLtwQFG/uQIGWFJkGBiwIQcd+C12Y4mHFLqdQOkI8UA==",
 			"dependencies": {
-				"@natlibfi/marc-record": "^8.0.0",
+				"@natlibfi/marc-record": "^8.0.2",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
-				"@natlibfi/sru-client": "^6.0.5",
+				"@natlibfi/sru-client": "^6.0.8",
 				"debug": "^4.3.4",
 				"deep-eql": "^4.1.3",
 				"http-status": "^1.7.3",
-				"moment": "^2.29.4",
-				"nock": "^13.3.8",
+				"moment": "^2.30.1",
+				"nock": "^13.5.0",
 				"node-fetch": "^2.7.0"
 			},
 			"engines": {
@@ -2190,9 +2178,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-import-commons": {
-			"version": "10.2.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-import-commons/-/melinda-record-import-commons-10.2.1.tgz",
-			"integrity": "sha512-FtD3wsctPXDh7v7qB34pE7qETcx5MTn9R+B5l85TCcJAB+W28k9zo690saEYx3+1sTiKAKgtbu5lFtx3n/h88A==",
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-import-commons/-/melinda-record-import-commons-10.2.2.tgz",
+			"integrity": "sha512-UccD3R6A9+w1k2i6tSvw8NnFdde3FgGlL3rv343GjG8Eve2Z1JOK7gjLdQqL+nuKloicJNSgO3i469OEFcwqcg==",
 			"dependencies": {
 				"@natlibfi/melinda-backend-commons": "^2.2.1",
 				"@natlibfi/melinda-commons": "^13.0.6",
@@ -2211,12 +2199,12 @@
 			}
 		},
 		"node_modules/@natlibfi/sru-client": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.5.tgz",
-			"integrity": "sha512-CMoPVQrMT/+LWM0Bo85W71//T5E2AbmfqnAODVkfR74V7zQ8Oreej6h0QS6/5bMHkvfE5QO9to5yGLJr9b+e4w==",
+			"version": "6.0.8",
+			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-6.0.8.tgz",
+			"integrity": "sha512-U1zF9hhGv3HyfINxQlGO7TieaEq5CY0hGh0RM/4fR23vfj1yRm5bb60pZjk5SaLTFYkNyUC7iyNU7mjBzhii+g==",
 			"dependencies": {
 				"debug": "^4.3.4",
-				"http-status": "^1.6.2",
+				"http-status": "^1.7.3",
 				"node-fetch": "^2.7.0",
 				"xml2js": "^0.6.2"
 			},
@@ -2517,9 +2505,9 @@
 			"dev": true
 		},
 		"node_modules/acorn": {
-			"version": "8.11.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-			"integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+			"version": "8.11.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -2688,13 +2676,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.6.tgz",
-			"integrity": "sha512-jhHiWVZIlnPbEUKSSNb9YoWcQGdlTLq7z1GHL4AjFxaoOUMuuEVJ+Y4pAaQUGOGk93YsVCKPbqbfw3m0SM6H8Q==",
+			"version": "0.4.7",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.7.tgz",
+			"integrity": "sha512-LidDk/tEGDfuHW2DWh/Hgo4rmnw3cduK6ZkOI1NPFceSK3n/yAGeOsNT7FLnSGHkXj3RHGSEVkN3FsCTY6w2CQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.22.6",
-				"@babel/helper-define-polyfill-provider": "^0.4.3",
+				"@babel/helper-define-polyfill-provider": "^0.4.4",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -2702,12 +2690,12 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.8.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.6.tgz",
-			"integrity": "sha512-leDIc4l4tUgU7str5BWLS2h8q2N4Nf6lGZP6UrNDxdtfF2g69eJ5L0H7S8A5Ln/arfFAfHor5InAdZuIOwZdgQ==",
+			"version": "0.8.7",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.7.tgz",
+			"integrity": "sha512-KyDvZYxAzkC0Aj2dAPyDzi2Ym15e5JKZSK+maI7NAwSqofvuFglbSsxE7wUOvTg9oFVnHMzVzBKcqEb4PJgtOA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.4.3",
+				"@babel/helper-define-polyfill-provider": "^0.4.4",
 				"core-js-compat": "^3.33.1"
 			},
 			"peerDependencies": {
@@ -2715,12 +2703,12 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.3.tgz",
-			"integrity": "sha512-8sHeDOmXC8csczMrYEOf0UTNa4yE2SxV5JGeT/LP1n0OYVDUUFPxG9vdk2AlDlIit4t+Kf0xCtpgXPBwnn/9pw==",
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.4.tgz",
+			"integrity": "sha512-S/x2iOCvDaCASLYsOOgWOq4bCfKYVqvO/uxjkaYyZ3rVsVE3CeAI/c84NpyuBBymEgNvHgjEot3a9/Z/kXvqsg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.4.3"
+				"@babel/helper-define-polyfill-provider": "^0.4.4"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -2782,9 +2770,9 @@
 			"dev": true
 		},
 		"node_modules/browserslist": {
-			"version": "4.22.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-			"integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+			"version": "4.22.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
+			"integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2800,9 +2788,9 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001541",
-				"electron-to-chromium": "^1.4.535",
-				"node-releases": "^2.0.13",
+				"caniuse-lite": "^1.0.30001565",
+				"electron-to-chromium": "^1.4.601",
+				"node-releases": "^2.0.14",
 				"update-browserslist-db": "^1.0.13"
 			},
 			"bin": {
@@ -2871,9 +2859,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001564",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001564.tgz",
-			"integrity": "sha512-DqAOf+rhof+6GVx1y+xzbFPeOumfQnhYzVnZD6LAXijR77yPtm9mfOcqOnT3mpnJiZVT+kwLAFnRlZcIz+c6bg==",
+			"version": "1.0.30001577",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001577.tgz",
+			"integrity": "sha512-rs2ZygrG1PNXMfmncM0B5H1hndY5ZCC9b5TkFaVNfZ+AUlyqcMyVIQtc3fsezi0NUCk5XZfDf9WS6WxMxnfdrg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2890,9 +2878,9 @@
 			]
 		},
 		"node_modules/chai": {
-			"version": "4.3.10",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
-			"integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+			"integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
 			"dev": true,
 			"dependencies": {
 				"assertion-error": "^1.1.0",
@@ -3227,9 +3215,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.593",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.593.tgz",
-			"integrity": "sha512-c7+Hhj87zWmdpmjDONbvNKNo24tvmD4mjal1+qqTYTrlF0/sNpAcDlU0Ki84ftA/5yj3BF2QhSGEC0Rky6larg=="
+			"version": "1.4.633",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.633.tgz",
+			"integrity": "sha512-7BvxzXrHFliyQ1oZc6NRMjyEaKOO1Ma1NY98sFZofogWlm+klLWSgrDw7EhatiMgi4R4NV+iWxDdxuIKXtPbOw=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -3277,15 +3265,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.54.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.54.0.tgz",
-			"integrity": "sha512-NY0DfAkM8BIZDVl6PgSa1ttZbx3xHgJzSNJKYcQglem6CppHyMhRIQkBVSSMaSRnLhig3jsDbEzOjwCVt4AmmA==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+			"integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
-				"@eslint/eslintrc": "^2.1.3",
-				"@eslint/js": "8.54.0",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.56.0",
 				"@humanwhocodes/config-array": "^0.11.13",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -4704,9 +4692,9 @@
 			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
 		},
 		"node_modules/isbn3": {
-			"version": "1.1.43",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.43.tgz",
-			"integrity": "sha512-RFRg0DILq6FG9O7oITmH0tUo5i5Ao3Wth2ldFHNwi5GVXKX6LbHqIvOekeEwZty/lD0RHoTgUqSlEShwa86oiw==",
+			"version": "1.1.44",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.44.tgz",
+			"integrity": "sha512-lHwBx85hTHPwtSHrieC+AG73doLOIpNbb6OEchh3v2MZrxKJ+HN24ksgparYjRRgNtzVxzuNQd8VBZMEBxcMBw==",
 			"bin": {
 				"isbn": "bin/isbn",
 				"isbn-audit": "bin/isbn-audit",
@@ -5477,9 +5465,9 @@
 			}
 		},
 		"node_modules/moment": {
-			"version": "2.29.4",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+			"version": "2.30.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
 			"engines": {
 				"node": "*"
 			}
@@ -5501,9 +5489,9 @@
 			"dev": true
 		},
 		"node_modules/nock": {
-			"version": "13.3.8",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-13.3.8.tgz",
-			"integrity": "sha512-96yVFal0c/W1lG7mmfRe7eO+hovrhJYd2obzzOZ90f6fjpeU/XNvd9cYHZKZAQJumDfhXgoTpkpJ9pvMj+hqHw==",
+			"version": "13.5.0",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-13.5.0.tgz",
+			"integrity": "sha512-9hc1eCS2HtOz+sE9W7JQw/tXJktg0zoPSu48s/pYe73e25JW9ywiowbqnUSd7iZPeVawLcVpPZeZS312fwSY+g==",
 			"dependencies": {
 				"debug": "^4.1.0",
 				"json-stringify-safe": "^5.0.1",
@@ -5545,18 +5533,18 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
 		},
 		"node_modules/nodemon": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.1.tgz",
-			"integrity": "sha512-g9AZ7HmkhQkqXkRc20w+ZfQ73cHLbE8hnPbtaFbFtCumZsjyMhKk9LajQ07U5Ux28lvFjZ5X7HvWR1xzU8jHVw==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.3.tgz",
+			"integrity": "sha512-7jH/NXbFPxVaMwmBCC2B9F/V6X1VkEdNgx3iu9jji8WxWcvhMWkmhNWhI5077zknOnZnBzba9hZP6bCPJLSReQ==",
 			"dev": true,
 			"dependencies": {
 				"chokidar": "^3.5.2",
-				"debug": "^3.2.7",
+				"debug": "^4",
 				"ignore-by-default": "^1.0.1",
 				"minimatch": "^3.1.2",
 				"pstree.remy": "^1.1.8",
@@ -5575,15 +5563,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/nodemon"
-			}
-		},
-		"node_modules/nodemon/node_modules/debug": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.1.1"
 			}
 		},
 		"node_modules/nodemon/node_modules/lru-cache": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-record-import-transformer-helmet.git"
 	},
 	"license": "AGPL-3.0+",
-	"version": "1.0.2-alpha.5",
+	"version": "1.0.3-alpha.3",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"


### PR DESCRIPTION
* Bump the development-dependencies group with 9 updates (#133) | Package | From | To |
| --- | --- | --- |
| [@babel/core](https://github.com/babel/babel/tree/HEAD/packages/babel-core) | `7.23.3` | `7.23.7` | | [@babel/plugin-transform-runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-transform-runtime) | `7.23.4` | `7.23.7` | | [@babel/preset-env](https://github.com/babel/babel/tree/HEAD/packages/babel-preset-env) | `7.23.3` | `7.23.8` | | [@babel/register](https://github.com/babel/babel/tree/HEAD/packages/babel-register) | `7.22.15` | `7.23.7` | | [@natlibfi/fixugen](https://github.com/natlibfi/fixugen-js) | `2.0.2` | `2.0.4` | | [@natlibfi/fixura](https://github.com/natlibfi/fixura-js) | `3.0.2` | `3.0.4` | | [chai](https://github.com/chaijs/chai) | `4.3.10` | `4.4.0` | | [eslint](https://github.com/eslint/eslint) | `8.54.0` | `8.56.0` | | [nodemon](https://github.com/remy/nodemon) | `3.0.1` | `3.0.2` |

* Bump the production-dependencies group with 8 updates (#132) | Package | From | To |
| --- | --- | --- |
| [@babel/runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-runtime) | `7.23.4` | `7.23.8` | | [@natlibfi/marc-record](https://github.com/natlibfi/marc-record-js) | `8.0.0` | `8.0.2` | | [@natlibfi/marc-record-validate](https://github.com/natlibfi/marc-record-validate) | `8.0.3` | `8.0.4` | | [@natlibfi/marc-record-validators-melinda](https://github.com/natlibfi/marc-record-validators-melinda) | `10.15.1` | `10.15.2` | | [@natlibfi/melinda-backend-commons](https://github.com/natlibfi/melinda-backend-commons-js) | `2.2.2` | `2.2.5` | | [@natlibfi/melinda-commons](https://github.com/natlibfi/melinda-commons-js) | `13.0.8` | `13.0.10` | | [@natlibfi/melinda-record-import-commons](https://github.com/natlibfi/melinda-record-import-commons-js) | `10.2.1` | `10.2.2` | | [moment](https://github.com/moment/moment) | `2.29.4` | `2.30.1` |

* Bump the production-dependencies group with 7 updates (#142) | Package | From | To |
| --- | --- | --- |
| [@babel/runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-runtime) | `7.23.4` | `7.23.8` | | [@natlibfi/marc-record](https://github.com/natlibfi/marc-record-js) | `8.0.0` | `8.1.0` | | [@natlibfi/marc-record-validate](https://github.com/natlibfi/marc-record-validate) | `8.0.3` | `8.0.5` | | [@natlibfi/marc-record-validators-melinda](https://github.com/natlibfi/marc-record-validators-melinda) | `10.15.1` | `10.15.5` | | [@natlibfi/melinda-backend-commons](https://github.com/natlibfi/melinda-backend-commons-js) | `2.2.2` | `2.2.6` | | [@natlibfi/melinda-commons](https://github.com/natlibfi/melinda-commons-js) | `13.0.8` | `13.0.11` | | [@natlibfi/melinda-record-import-commons](https://github.com/natlibfi/melinda-record-import-commons-js) | `10.2.1` | `10.2.2` |

* Bump the development-dependencies group with 9 updates (#140) | Package | From | To |
| --- | --- | --- |
| [@babel/core](https://github.com/babel/babel/tree/HEAD/packages/babel-core) | `7.23.3` | `7.23.7` | | [@babel/plugin-transform-runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-transform-runtime) | `7.23.4` | `7.23.7` | | [@babel/preset-env](https://github.com/babel/babel/tree/HEAD/packages/babel-preset-env) | `7.23.3` | `7.23.8` | | [@babel/register](https://github.com/babel/babel/tree/HEAD/packages/babel-register) | `7.22.15` | `7.23.7` | | [@natlibfi/fixugen](https://github.com/natlibfi/fixugen-js) | `2.0.2` | `2.0.4` | | [@natlibfi/fixura](https://github.com/natlibfi/fixura-js) | `3.0.2` | `3.0.4` | | [chai](https://github.com/chaijs/chai) | `4.3.10` | `4.4.1` | | [eslint](https://github.com/eslint/eslint) | `8.54.0` | `8.56.0` | | [nodemon](https://github.com/remy/nodemon) | `3.0.1` | `3.0.3` |

* node-tests: v16.x -> v19.x
* Do not run quay.io for dependabot PRs

* 1.0.3-alpha.3